### PR TITLE
Add --branch option to checkout NachOS branch in `./install.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,26 @@ cd nachos-docker
 That's it! The script will automatically set up everything you need.  
 就這樣！安裝腳本會自動設置你需要的一切。
 
+### Use a specific NachOS branch | 指定 NachOS 分支
+
+```bash
+./install.sh --branch hw2
+# or
+./install.sh -b hw2
+```
+
+**Notes | 注意：**
+
+English:
+- If `NachOS/` does not exist, the script will clone and checkout the branch.
+- If `NachOS/` already exists, the script will try to `git fetch` + `git checkout <branch>`.
+- If you have local changes, Git may block checkout. Please commit/stash or use a clean copy.
+
+中文：
+- 若專案中沒有 `NachOS/` 資料夾，安裝腳本會自動 clone 並切換到指定分支。
+- 若 `NachOS/` 已存在，安裝腳本會執行 `git fetch` 並嘗試 `git checkout <branch>`。
+- 若有本機修改，Git 可能會阻擋切換分支；請先 commit/stash，或使用乾淨副本再重試。
+
 ## 🎯 Quick Start | 快速開始
 
 **Start development environment | 啟動開發環境:**

--- a/install.sh
+++ b/install.sh
@@ -15,10 +15,29 @@ NC='\033[0m' # No Color
 
 # Configuration
 DOCKER_IMAGE="nachos:optimized"
+BRANCH="" # optional: target NachOS git branch to checkout
 
 echo -e "${BLUE}🚀 NachOS Docker Installation${NC}"
 echo -e "${CYAN}Cross-platform NachOS development environment${NC}"
 echo ""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --branch|-b)
+            BRANCH="$2"
+            shift 2
+            ;;
+        *)
+            # ignore unknown flags for backward compatibility
+            shift
+            ;;
+    esac
+done
+
+if [[ -n "$BRANCH" ]]; then
+    echo -e "${YELLOW}🌿 Target branch specified:${NC} ${BRANCH}"
+fi
 
 # Function to check command existence
 check_command() {
@@ -80,12 +99,34 @@ if [ ! -d "NachOS" ]; then
     git clone https://github.com/wynn1212/NachOS.git NachOS
     if [ $? -eq 0 ]; then
         echo -e "${GREEN}✅ NachOS source downloaded${NC}"
+        if [[ -n "$BRANCH" ]]; then
+            echo -e "${YELLOW}🔁 Switching to branch:${NC} ${BRANCH}"
+            (
+                cd NachOS && \
+                git fetch --all --tags && \
+                git checkout "$BRANCH"
+            ) || {
+                echo -e "${RED}❌ Failed to checkout branch '${BRANCH}'${NC}"
+                exit 1
+            }
+        fi
     else
         echo -e "${RED}❌ Failed to download NachOS source${NC}"
         exit 1
     fi
 else
     echo -e "${GREEN}✅ NachOS source already available${NC}"
+    if [[ -n "$BRANCH" ]]; then
+        echo -e "${YELLOW}🔁 Switching to branch in existing repo:${NC} ${BRANCH}"
+        (
+            cd NachOS && \
+            git fetch --all --tags && \
+            git checkout "$BRANCH"
+        ) || {
+            echo -e "${RED}❌ Failed to checkout branch '${BRANCH}' in existing repo${NC}"
+            exit 1
+        }
+    fi
 fi
 echo ""
 


### PR DESCRIPTION
為 `install.sh` 加入可指定 NachOS 目標分支的功能，並在 `README.md` 補充對應說明（中英對照），讓使用者能在安裝時直接切換至作業分支（如 `hw2`）進行打包與測試。

<img width="249" height="224" alt="image" src="https://github.com/user-attachments/assets/63ca6237-d5f5-4f84-b298-fdd5a9cd20a7" />


### 變更內容
- install.sh
  - 新增參數 `--branch <name>` / `-b <name>` 用於指定欲 checkout 的 NachOS 分支
  - 若 `NachOS/` 不存在：clone 後自動 `git checkout <branch>`
  - 若 `NachOS/` 已存在：執行 `git fetch --all --tags` 後 `git checkout <branch>`
  - 對分支切換失敗提供明確錯誤回報
- README.md
  - 新增「指定分支安裝」使用說明與範例
  - 新增 Notes 區塊（中英對照），說明 `NachOS/` 存在與否時的行為

### 使用方式
```bash
# 指定 NachOS 分支（英文/中文相同）
./install.sh --branch hw2
# 或
./install.sh -b hw2
```

### 注意事項
- 若 `NachOS/` 已存在且有本機未提交修改，Git 可能會阻擋 `checkout`。
  - 可先 `git add . && git commit -m "save work"` 再切換
  - 或使用 `git stash -u` 暫存修改後切換
  - 或使用乾淨副本（移走現有資料夾、重新 clone）

### 測試項目
- 未存在 `NachOS/`：安裝腳本會自動 clone 並正確切換到指定分支
- 已存在 `NachOS/` 無修改：能 `fetch` 並正確 `checkout` 指定分支
- 已存在 `NachOS/` 有未提交修改：能顯示合理錯誤提示

### 影響範圍
- 僅影響安裝流程與文件，不影響容器內編譯與執行流程

<img width="239" height="217" alt="image" src="https://github.com/user-attachments/assets/e4fa18ff-d779-4e67-af15-d65eca786331" />
